### PR TITLE
fix: speed up e2e tests in CI by reusing build artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,14 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx playwright install --with-deps
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
+        env:
+          CI_USE_PREVIEW: true
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      ASTRO_BASE: /
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,6 +69,11 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
 
   e2e-tests:
     name: E2E Tests
@@ -87,7 +92,10 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npm run build
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
       - run: npm run test:e2e
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,6 +61,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      ASTRO_BASE: /
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem
E2E tests were consistently timing out in CI ([example run](https://github.com/taurheim/LastWave/actions/runs/24592619080/job/71917043123)). The Astro dev server took >120s to start, exceeding the \webServer.timeout\, and when tests did run they took 7+ minutes.

## Root Cause
The \2e-tests\ jobs declared \
eeds: build\ but never used the build output. Instead they either:
- Started \
pm run dev\ (ci.yml) — slow dev server that timed out
- Ran \
pm run build\ again (pr.yml) — redundant rebuild inside the Playwright container

## Changes

### ci.yml
- **Build job**: Set \ASTRO_BASE=/\ so the artifact is built with the correct base path for e2e tests
- **E2E job**: Download the \dist/\ artifact instead of starting a dev server, set \CI_USE_PREVIEW=true\ to use \
pm run preview\ (static serving), install only chromium (all test projects use Desktop Chrome)

### pr.yml
- **Build job**: Set \ASTRO_BASE=/\ and upload \dist/\ as an artifact
- **E2E job**: Download the \dist/\ artifact instead of rebuilding, removed redundant \
pm run build\ step

## Result
E2E job dropped from **timing out at 2+ minutes** (server never started) to **~70 seconds total** including all setup.