### PR TITLE
fix(ci): set ASTRO_BASE=/ at e2e job level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: build
+    env:
+      ASTRO_BASE: /
+      CI_USE_PREVIEW: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -92,8 +95,6 @@ jobs:
           path: dist/
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
-        env:
-          CI_USE_PREVIEW: true
       - uses: actions/upload-artifact@v4
         if: failure()
         with:


### PR DESCRIPTION
## Problem
After PR #69, the CI workflow's E2E tests still time out: [run](https://github.com/taurheim/LastWave/actions/runs/24607785522/job/71956847187).

## Root Cause
\stro preview\ reads \process.env.ASTRO_BASE ?? '/lastwave/'\ from \stro.config.mjs\. The PR workflow sets \ASTRO_BASE: /\ at the **job** level (so it applies to both build AND preview steps), but ci.yml only set it on the build job. So the dist artifact was built for base \/\, but \stro preview\ then tried to serve it at \/lastwave/\ — and Playwright's webServer health check on \http://localhost:4321/\ timed out.

## Fix
Move \ASTRO_BASE: /\ and \CI_USE_PREVIEW: true\ to the e2e job's \nv\ block, matching the pattern already used in pr.yml.