### PR TITLE
fix(ci): build deploy artifact with /lastwave/ base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      ASTRO_BASE: /
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -68,6 +66,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      # Build with default base (/lastwave/) matching the production deploy path.
       - run: npm run build
       - uses: actions/upload-artifact@v4
         with:
@@ -78,7 +77,9 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: build
+    env:
+      ASTRO_BASE: /
+      CI_USE_PREVIEW: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -86,14 +87,10 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
+      # E2E uses astro preview at http://localhost:4321/ so needs base=/; build its own dist.
+      - run: npm run build
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
-        env:
-          CI_USE_PREVIEW: true
       - uses: actions/upload-artifact@v4
         if: failure()
         with:


### PR DESCRIPTION
## Problem

https://savas.ca/lastwave returns 404s — all assets (/_astro/*.js, *.css, favicon.ico) 404 because the deployed HTML references them at root instead of /lastwave/.

## Root cause

PR #69 set `ASTRO_BASE=/` on the CI **build** job to fix E2E tests, but the CD workflow deploys that same artifact to `savas.ca/lastwave/` on Namecheap. So the artifact's base path no longer matched the deploy path.

## Fix

- **build** job: remove `ASTRO_BASE=/` override → uses default `/lastwave/` (matches prod deploy path)
- **e2e-tests** job: builds its own dist with `ASTRO_BASE=/` since `astro preview` serves at root. No longer consumes the deploy artifact.

After merge, CD will redeploy with correct asset URLs.