### PR TITLE
fix: remove hardcoded default username from input box

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -113,8 +113,8 @@ export const useLastWaveStore = create<LastWaveState>((set, _get) => ({
 
   // Options
   rendererOptions: {},
-  dataSourceOptions: { username: 'Taurheim', service: 'lastfm' },
-  setRendererOption: (key, value) =>
+  dataSourceOptions: { username: '', service: 'lastfm' },
+  setRendererOption:(key, value) =>
     set((state) => ({ rendererOptions: { ...state.rendererOptions, [key]: value } })),
   setDataSourceOption: (key, value) =>
     set((state) => ({ dataSourceOptions: { ...state.dataSourceOptions, [key]: value } })),
@@ -186,7 +186,7 @@ export const useLastWaveStore = create<LastWaveState>((set, _get) => ({
       logs: [],
       toasts: [],
       rendererOptions: {},
-      dataSourceOptions: { username: 'Taurheim', service: 'lastfm' },
+      dataSourceOptions: { username: '', service: 'lastfm' },
       showOptions: true,
       showLoadingBar: false,
       showActions: false,

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -114,7 +114,7 @@ export const useLastWaveStore = create<LastWaveState>((set, _get) => ({
   // Options
   rendererOptions: {},
   dataSourceOptions: { username: '', service: 'lastfm' },
-  setRendererOption:(key, value) =>
+  setRendererOption: (key, value) =>
     set((state) => ({ rendererOptions: { ...state.rendererOptions, [key]: value } })),
   setDataSourceOption: (key, value) =>
     set((state) => ({ dataSourceOptions: { ...state.dataSourceOptions, [key]: value } })),


### PR DESCRIPTION
Removes the hardcoded 'Taurheim' username that was left over from testing in the initial and reset data source options. The username input now starts empty so users see the placeholder prompting for their own username.