### PR TITLE
Update Spotify modal copy to emphasize one-time setup

### DIFF
--- a/src/components/SpotifyModal.tsx
+++ b/src/components/SpotifyModal.tsx
@@ -52,7 +52,7 @@ export default function SpotifyModal({ open, onClose }: SpotifyModalProps) {
           I want to see stats for my Spotify listening history!
         </h2>
 
-        <p className="mb-6 text-sm leading-relaxed text-lw-muted sm:text-base">
+        <p className="mb-4 text-sm leading-relaxed text-lw-muted sm:text-base">
           Unfortunately, Spotify does not expose a public API to access your music listening
           history. To use LastWave (and{' '}
           <a
@@ -64,6 +64,12 @@ export default function SpotifyModal({ open, onClose }: SpotifyModalProps) {
             many more visualization tools
           </a>
           ), you will need to set up last.fm and/or ListenBrainz.
+        </p>
+
+        <p className="mb-6 text-sm leading-relaxed text-lw-muted sm:text-base">
+          <strong className="font-semibold text-lw-text">You&rsquo;ll only need to do this once</strong>{' '}
+          - once you&rsquo;ve set it up, you&rsquo;ll be able to use LastWave and other tools that
+          use your listening history for all your future listening too!
         </p>
 
         {/* Section heading */}

--- a/src/components/SpotifyModal.tsx
+++ b/src/components/SpotifyModal.tsx
@@ -67,7 +67,9 @@ export default function SpotifyModal({ open, onClose }: SpotifyModalProps) {
         </p>
 
         <p className="mb-6 text-sm leading-relaxed text-lw-muted sm:text-base">
-          <strong className="font-semibold text-lw-text">You&rsquo;ll only need to do this once</strong>{' '}
+          <strong className="font-semibold text-lw-text">
+            You&rsquo;ll only need to do this once
+          </strong>{' '}
           - once you&rsquo;ve set it up, you&rsquo;ll be able to use LastWave and other tools that
           use your listening history for all your future listening too!
         </p>


### PR DESCRIPTION
Updates the Spotify modal to reassure users that the last.fm/ListenBrainz setup is a one-time process.

- Splits the explanation into two paragraphs
- Adds emphasis on `You'll only need to do this once`
- Uses a regular hyphen (not em-dash)