### PR TITLE
Fix DM Sans 404 by prefixing runtime URLs with Astro base path

### DIFF
--- a/src/components/ImageActions.tsx
+++ b/src/components/ImageActions.tsx
@@ -12,7 +12,7 @@ import { fetchWithRetry } from '@/core/http/fetchWithRetry';
 async function inlineFontCss(fontFamily: string): Promise<string> {
   if (fontFamily === 'DM Sans') {
     try {
-      const res = await fetch('/fonts/DMSans-Variable.woff2');
+      const res = await fetch(`${import.meta.env.BASE_URL}fonts/DMSans-Variable.woff2`);
       const buf = await res.arrayBuffer();
       const b64 = btoa(String.fromCharCode(...new Uint8Array(buf)));
       return `@font-face{font-family:'DM Sans';src:url('data:font/woff2;base64,${b64}') format('woff2-variations');font-weight:100 1000;font-style:normal;}`;

--- a/src/components/WaveVisualization.tsx
+++ b/src/components/WaveVisualization.tsx
@@ -475,11 +475,16 @@ export default memo(function WaveVisualization({
     // in restrictive environments (e.g. Meta in-app browsers, Private Relay).
     const defs = svg.append('defs');
     if (fontFamily === 'DM Sans') {
+      // Build an absolute URL so the SVG resolves the font when viewed
+      // standalone (e.g. rasterized through <img> for PNG export, where the
+      // document base is a blob: URL). Respect Astro's configured base path.
       const origin = typeof window !== 'undefined' ? window.location.origin : '';
+      const base = import.meta.env.BASE_URL; // e.g. "/lastwave/"
+      const fontHref = `${origin}${base}fonts/DMSans-Variable.woff2`;
       defs
         .append('style')
         .text(
-          `@font-face{font-family:'DM Sans';src:url('${origin}/fonts/DMSans-Variable.woff2') format('woff2-variations');font-weight:100 1000;font-style:normal;font-display:swap;}`,
+          `@font-face{font-family:'DM Sans';src:url('${fontHref}') format('woff2-variations');font-weight:100 1000;font-style:normal;font-display:swap;}`,
         );
     } else {
       const fontUrl = `https://fonts.googleapis.com/css2?family=${encodeURIComponent(fontFamily).replace(/%20/g, '+')}&display=swap`;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -48,7 +48,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://savas.ca
 
     <link
       rel="preload"
-      href="/fonts/DMSans-Variable.woff2"
+      href={`${import.meta.env.BASE_URL}fonts/DMSans-Variable.woff2`}
       as="font"
       type="font/woff2"
       crossorigin


### PR DESCRIPTION
Follow-up to #75. The self-hosted DM Sans file 404s in production because the site is served under the `/lastwave/` base path, but three runtime references hardcoded `/fonts/...` at the origin root:

- `<link rel=preload href=/fonts/DMSans-Variable.woff2>` in `BaseLayout.astro`
- `fetch('/fonts/DMSans-Variable.woff2')` in `ImageActions.inlineFontCss`
- The SVG `@font-face` `src: url(...)` injected from `WaveVisualization.tsx`

Vite rewrites CSS `url()` references at build time (which is why the page's own `@font-face` in `BaseLayout.astro` worked), but it doesn't rewrite HTML `href` attributes, runtime `fetch` calls, or strings injected into SVG `<style>` tags.

### Fix
All three sites now prefix the path with `import.meta.env.BASE_URL` (`/lastwave/` in production, `/` in dev), so the URL resolves to `https://savas.ca/lastwave/fonts/DMSans-Variable.woff2`.

### Verification
`npm run build` ΓÇö confirmed the built `index.html` now emits `<link rel=preload href=/lastwave/fonts/DMSans-Variable.woff2>`.