### PR TITLE
Pin line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Ensure consistent LF line endings across platforms. Prettier's default
+# `endOfLine: "lf"` would otherwise flag files checked out on Windows (where
+# git's autocrlf can convert to CRLF) as needing reformatting.
+* text=auto eol=lf
+
+# Binary files should never be touched.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.eot binary


### PR DESCRIPTION
Prerequisite for #(follow-up) that adds `lint` + `format:check` to `npm run verify`.

Prettier's default `endOfLine` is `lf`. On Windows, git's `core.autocrlf` can check files out with CRLF, causing `format:check` to flag every source file as needing reformat locally even though CI on Linux passes. This makes `verify` effectively unusable on Windows if we add format:check to it.

### Fix
Add a `.gitattributes` with `* text=auto eol=lf` so git always writes LF to the working tree regardless of platform, plus explicit `binary` entries for image/font formats so they're never touched.

### Verification
- `npm run format:check` ΓÇö `All matched files use Prettier code style!` on Windows after re-checkout.
- `npm run lint` ΓÇö passes (same pre-existing warnings as `main`).
- No source files were modified: the repo index was already LF, only Windows working-tree checkouts were CRLF. Fresh clones on any platform now get LF.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>