### PR TITLE
Include lint + format:check in `npm run verify`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,astro,css,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,astro,css,json}\"",
     "typecheck": "tsc --noEmit --project tsconfig.check.json",
-    "verify": "npm run typecheck && npm run test && npm run build"
+    "verify": "npm run lint && npm run format:check && npm run typecheck && npm run test && npm run build"
   },
   "dependencies": {
     "@astrojs/react": "^4.2.0",


### PR DESCRIPTION
CI runs five checks on every PR (`lint`, `format:check`, `typecheck`, `test`, `build`) but `verify` only ran the last three. As a result, format/lint regressions passed locally and failed CI — exactly what happened in #75, where a prettier miss slipped through.

### Change
`verify` now runs all five, in fast-to-slow order so trivial issues fail early:

`npm run lint && npm run format:check && npm run typecheck && npm run test && npm run build`

Safe to land now that #77 pinned line endings to LF — Windows contributors no longer hit spurious `format:check` failures on fresh checkouts.

### Verification
`npm run verify` on Windows ΓÇö all five steps pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>