### PR TITLE
feat: add build versioning with git SHA and CI run number

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,8 @@ on:
     types: [completed]
     branches: [main]
 
+run-name: "Deploy #${{ github.run_number }} — ${{ github.event.workflow_run.head_sha }}"
+
 jobs:
   deploy:
     name: Deploy to Namecheap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
 
+run-name: "CI #${{ github.run_number }} — ${{ github.event.head_commit.message }}"
+
 jobs:
   lint:
     name: Lint & Format
@@ -66,8 +68,18 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Generate version.json
+        run: |
+          echo '{
+            "sha": "'${GITHUB_SHA::7}'",
+            "fullSha": "'$GITHUB_SHA'",
+            "run": '$GITHUB_RUN_NUMBER',
+            "builtAt": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
+          }' > public/version.json
       # Build with default base (/lastwave/) matching the production deploy path.
       - run: npm run build
+        env:
+          GIT_SHA: ${{ github.sha }}
       - uses: actions/upload-artifact@v4
         with:
           name: dist

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules
 .claude/
 .validation/
 
+# Generated at build time
+public/version.json
+
 # local env files
 .env.local
 .env.*.local

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import { ClientRouter } from 'astro:transitions';
 import ErrorToast from '@/components/ErrorToast';
 import '@/styles/global.css';
+import { execSync } from 'child_process';
 
 interface Props {
   title?: string;
@@ -16,6 +17,18 @@ const {
 } = Astro.props;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://savas.ca/lastwave');
+
+const gitSha = (
+  process.env.GIT_SHA ??
+  (() => {
+    try {
+      return execSync('git rev-parse --short HEAD').toString().trim();
+    } catch {
+      return 'dev';
+    }
+  })()
+).slice(0, 7);
+const buildNumber = process.env.GITHUB_RUN_NUMBER ?? 'local';
 ---
 
 <!doctype html>
@@ -225,7 +238,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://savas.ca
         class="via-lw-border mx-auto mb-2 h-px w-12 bg-gradient-to-r from-transparent to-transparent"
       >
       </div>
-      LastWave &middot; built by <a
+      <span title={`${gitSha} · Build ${buildNumber}`}>LastWave</span> &middot; built by <a
         href="https://savas.ca"
         class="hover:text-lw-accent transition-colors">Niko Savas</a
       >


### PR DESCRIPTION
## What

Adds build-time versioning so the live site can be tied to a specific CI run.

### Changes
- **Vite define**: Injects \__GIT_SHA__\ (short commit SHA) and \__BUILD_NUMBER__\ (CI run number) at build time
- **Footer indicator**: Subtle SHA shown in footer, build number on hover
- **\ersion.json\**: Generated during CI build at \/lastwave/version.json\ — contains SHA, run number, and build timestamp for programmatic checks (\curl\)
- **Workflow run names**: CI shows \CI #42 — fix label overflow\, CD shows the deployed SHA

### How to use
- **Visual**: Check the footer for the git SHA
- **Programmatic**: \curl https://savas.ca/lastwave/version.json\
- **GitHub**: CI/CD run names now include version info

### Testing
- Build succeeds locally
- All 206 unit tests pass
- No changes to runtime behavior