### PR TITLE
fix: CD run-name references the CI run number it deploys

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,7 @@ on:
     types: [completed]
     branches: [main]
 
-run-name: "Deploy #${{ github.run_number }} — ${{ github.event.workflow_run.head_sha }}"
+run-name: "Deploy CI #${{ github.event.workflow_run.run_number }} — ${{ github.event.workflow_run.head_sha }}"
 
 jobs:
   deploy:


### PR DESCRIPTION
The CD workflow gets its own \github.run_number\, so Deploy #22 was deploying CI #21's artifacts — confusing.

Now uses \github.event.workflow_run.run_number\ so it shows **Deploy CI #21 — abc1234**, making traceability clear.