### PR TITLE
Hide commit hash in footer, show only on hover

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -242,7 +242,6 @@ const buildNumber = process.env.GITHUB_RUN_NUMBER ?? 'local';
         href="https://savas.ca"
         class="hover:text-lw-accent transition-colors">Niko Savas</a
       >
-      <span class="text-lw-muted/20 ml-1" title={`Build ${buildNumber}`}>{gitSha}</span>
     </footer>
     <script>
       import { initAnalytics } from '@/core/analytics/posthog';


### PR DESCRIPTION
Remove the visible commit SHA from the footer. The hash remains accessible via the title tooltip when hovering over 'LastWave'.